### PR TITLE
Adds instantclient support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -86,8 +86,8 @@
     [
       "OS=='win'", {
         "variables" : {
-          "oci_lib_dir%": "<!(IF DEFINED OCI_LIB_DIR (echo %OCI_LIB_DIR%) ELSE (echo C:\oracle\instantclient\sdk\lib\msvc))",
-          "oci_inc_dir%": "<!(IF DEFINED OCI_INC_DIR (echo %OCI_INC_DIR%) ELSE (echo C:\oracle\instantclient\sdk\include))",
+          "oci_lib_dir%": "<!(IF EXIST instantclient (echo %CD%\instantclient\sdk\lib\msvc) ELSE (IF DEFINED OCI_LIB_DIR (echo %OCI_LIB_DIR%) ELSE (echo C:\oracle\instantclient\sdk\lib\msvc)))",
+          "oci_inc_dir%": "<!(IF EXIST instantclient (echo %CD%\instantclient\sdk\include) ELSE (IF DEFINED OCI_INC_DIR (echo %OCI_INC_DIR%) ELSE (echo C:\oracle\instantclient\sdk\include)))",
         },
         "link_settings": {
              "libraries": [

--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -22,6 +22,31 @@ var oracledbInst;
 var Lob = require('./lob.js').Lob;
 var pool = require('./pool.js');
 var connection = require('./connection.js');
+var path = require('path');
+var fs = require('fs');
+var dir_home = path.join(__dirname, '../instantclient');
+var dir_lib = path.join(__dirname, '../instantclient/sdk/lib/msvc');
+var dir_inc = path.join(__dirname, '../instantclient/sdk/include');
+var stats_home;
+var stats_lib;
+var stats_inc;
+
+try {
+	stats_home = fs.lstatSync(dir_home);
+	stats_lib = fs.lstatSync(dir_lib);
+	stats_inc = fs.lstatSync(dir_inc);
+
+	// Is it a directory?
+	if (stats_home.isDirectory() && stats_lib.isDirectory() && stats_inc.isDirectory()) {
+		process.env['ORACLE_HOME'] = dir_home;
+		process.env['OCI_LIB_DIR'] = dir_lib;
+		process.env['OCI_INC_DIR'] = dir_inc;
+		process.env['PATH'] = process.env.ORACLE_HOME + ';' + process.env['PATH'];
+	}
+}
+catch (e) {
+	// Catch and just suppress error.
+}
 
 try {
   oracledbCLib =  require('../build/Release/oracledb');

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
       "async": "~0.9.0"
   },
   "scripts": {
+      "preinstall": "npm install instantclient",
       "test": "mocha -R spec --timeout 10000 test/*.js",
-      "testWindows": "mocha -R spec --timeout 0 test\\*.js"
+      "testWindows": "mocha -R spec --timeout 0 test\\*.js",
+      "install": "node_modules/.bin/instantclient && node-gyp rebuild"
   },
   "engines": {
     "node": ">=0.10.28 <6"


### PR DESCRIPTION
I have created https://github.com/bchr02/instantclient. This new node module provides the ability to easily install instantclient directly from Oracle. (I am willing to transfer ownership to Oracle)

This pull requests does the following:
1. on preinstall of node-oracledb installs instantclient (just the module not the actual instant client files)
2. on install of node-oracledb (before node-gyp prebuild) gives the user the option to install the instant client files in a new folder titled (instantclient) within the node-oracledb folder.
3. modifies lib/oracledb.js so that it detects whether this instantclient folder exists and if so automatically sets the necessary environment variables.
4. modifies binding.gyp so that if the new instantclient folder is found it is used instead of any environment variables or c:\instantclient. _Currently, I have only modified the Windows section. So we still need to update the Linux and Mac sections to work the same way._

Signed-off-by: Bill Christo billchristo@gmail.com
